### PR TITLE
Fix_assign_skill_exp to stage

### DIFF
--- a/Models/ResourceSkill.cs
+++ b/Models/ResourceSkill.cs
@@ -32,9 +32,8 @@ namespace DF_EvolutionAPI.Models
     public class ResourceSkillRequestModel
     {
         //public int ResourceSkillId { get; set; }
-        public int ResourceId { get; set; }
+        public int ResourceId { get; set; }       
         public int CreateBy { get; set; }
-        public byte? IsDeleted { get; set; }
         public List<SkillCategory> SkillCategories { get; set; }
     }
 

--- a/Services/KRATemplate/KRATemplateService.cs
+++ b/Services/KRATemplate/KRATemplateService.cs
@@ -11,7 +11,6 @@ using Microsoft.Extensions.Logging;
 using Microsoft.EntityFrameworkCore;
 using DF_EvolutionAPI.Models.Response;
 using Sprache;
-using Microsoft.EntityFrameworkCore.Metadata;
 
 namespace DF_EvolutionAPI.Services.KRATemplate
 {
@@ -320,7 +319,7 @@ namespace DF_EvolutionAPI.Services.KRATemplate
                         join function in _dbContext.TechFunctions
                         on template.FunctionId equals function.FunctionId
                         join businessId in _dbContext.BusinessUnits
-                        on template.BusinessUnitId equals businessId.BusinessUnitId
+                        on template.BusinessUnitId  equals businessId.BusinessUnitId
                         where template.IsActive == (int)Status.IS_ACTIVE && template.FunctionId == functionId
                         select new TemplateByFunction
                         {
@@ -341,37 +340,6 @@ namespace DF_EvolutionAPI.Services.KRATemplate
 
             return await query.OrderBy(templateName => templateName.Name).ToListAsync();
         }
-        //It will be use resolve a issue of function id 0
-        //public async Task<List<TemplateByFunction>> GetAllTemplatesByFunctionId(int functionId)
-        //{
-        //    int? funcId = functionId == 0 ? (int?)null : functionId;
-
-        //    var query = from template in _dbContext.PATemplates
-        //                join function in _dbContext.TechFunctions
-        //                    on template.FunctionId equals function.FunctionId
-        //                join businessId in _dbContext.BusinessUnits
-        //                    on template.BusinessUnitId equals businessId.BusinessUnitId
-        //                where template.IsActive == (int)Status.IS_ACTIVE
-        //                      && (funcId == null || template.FunctionId == funcId)
-        //                select new TemplateByFunction
-        //                {
-        //                    TemplateId = template.TemplateId,
-        //                    Name = template.Name,
-        //                    Description = template.Description,
-        //                    IsActive = template.IsActive,
-        //                    CreateBy = template.CreateBy,
-        //                    UpdateBy = template.UpdateBy,
-        //                    CreateDate = template.CreateDate,
-        //                    UpdateDate = template.UpdateDate,
-        //                    FunctionId = template.FunctionId,
-        //                    FunctionName = function.FunctionName,
-        //                    BusinessUnitId = businessId.BusinessUnitId,
-        //                    BusinessUnitName = businessId.BusinessUnitName,
-        //                };
-
-        //    return await query.OrderBy(templateName => templateName.Name).ToListAsync();
-        //}
-
 
         //Retrieves all active templates associated with the specified businessUnit ID.
         public async Task<List<TemplateByBusinessUnit>> GetAllTemplatesByBusinessUnitId(int businessUnitId)

--- a/Services/Resource/ResourceService.cs
+++ b/Services/Resource/ResourceService.cs
@@ -283,7 +283,12 @@ namespace DF_EvolutionAPI.Services
             DateTime today = DateTime.Today;
             DateTime joinDate = dateOfJoin.Value;
 
-            int monthsSinceJoin = ((today.Year - joinDate.Year) * 12) + today.Month - joinDate.Month;           
+            int monthsSinceJoin = ((today.Year - joinDate.Year) * 12) + today.Month - joinDate.Month;
+
+            if (today.Day < joinDate.Day)
+            {
+                monthsSinceJoin -= 1;
+            }
 
             int totalMonthsExperience = tenureInMonths + monthsSinceJoin;
 

--- a/Services/ResourceSkill/ResourceSkillService.cs
+++ b/Services/ResourceSkill/ResourceSkillService.cs
@@ -130,7 +130,7 @@ namespace DF_EvolutionAPI.Services
                                     existingSkill.RejectedComment = null;
                                     existingSkill.IsApproved = 0;
                                     existingSkill.ApprovedBy = 0;
-
+                                  
                                     _dbContext.ResourceSkills.Update(existingSkill);
                                 }
                                 else
@@ -229,7 +229,8 @@ namespace DF_EvolutionAPI.Services
                                     RejectedBy = 0,
                                     RejectedComment = null,
                                     IsApproved = 0,
-                                    ApprovedBy = 0
+                                    ApprovedBy = 0,
+                                    IsDeleted = 0
                                 };
                                 _dbContext.ResourceSkills.Add(newMainSkill);
                             }
@@ -259,7 +260,7 @@ namespace DF_EvolutionAPI.Services
                 from skill in skillGroup.DefaultIfEmpty()
                 join sub in _dbContext.SubSkills on rs.SubSkillId equals sub.SubSkillId into subSkillGroup
                 from subSkill in subSkillGroup.DefaultIfEmpty()
-                where rs.IsActive == (int)Status.IS_ACTIVE & rs.SkillId != 0
+                where rs.IsActive == (int)Status.IS_ACTIVE & rs.SkillId != 0 & rs.IsDeleted != 1
                 select new
                 {
                     r.ResourceId,
@@ -461,7 +462,7 @@ namespace DF_EvolutionAPI.Services
                         from skill in skillGroup.DefaultIfEmpty()
                         join sub in _dbContext.SubSkills.Where(subskill => subskill.IsActive == (int)Status.IS_ACTIVE) on rs.SubSkillId equals sub.SubSkillId into subSkillGroup
                         from subSkill in subSkillGroup.DefaultIfEmpty()
-                        where r.IsActive == (int)Status.IS_ACTIVE && r.StatusId == (int)Status.ACTIVE_RESOURCE_STATUS_ID && rs.IsActive == (int)Status.IS_ACTIVE
+                        where r.IsActive == (int)Status.IS_ACTIVE && r.StatusId == (int)Status.ACTIVE_RESOURCE_STATUS_ID && rs.IsActive == (int)Status.IS_ACTIVE && rs.IsDeleted != 1
                         select new
                         {
                             r.ResourceId,
@@ -600,7 +601,7 @@ namespace DF_EvolutionAPI.Services
                         from skill in skillGroup.DefaultIfEmpty()
                         join sub in _dbContext.SubSkills.Where(subskill => subskill.IsActive == 1) on rs.SubSkillId equals sub.SubSkillId into subSkillGroup
                         from subSkill in subSkillGroup.DefaultIfEmpty()
-                        where r.IsActive == (int)Status.IS_ACTIVE && r.StatusId == (int)Status.ACTIVE_RESOURCE_STATUS_ID && rs.IsActive == (int)Status.IS_ACTIVE
+                        where r.IsActive == (int)Status.IS_ACTIVE && r.StatusId == (int)Status.ACTIVE_RESOURCE_STATUS_ID && rs.IsActive == (int)Status.IS_ACTIVE && rs.IsDeleted != 1
                         select new
                         {
                             r.ResourceId,
@@ -694,7 +695,7 @@ namespace DF_EvolutionAPI.Services
                 from skill in skillGroup.DefaultIfEmpty()
                 join sub in _dbContext.SubSkills on rs.SubSkillId equals sub.SubSkillId into subSkillGroup
                 from subSkill in subSkillGroup.DefaultIfEmpty()
-                where rs.IsActive == (int)Status.IS_ACTIVE && r.ResourceId == resourceId
+                where rs.IsActive == (int)Status.IS_ACTIVE && r.ResourceId == resourceId && rs.IsDeleted != 1
                 select new
                 {
                     r.ResourceId,

--- a/Services/ResourceSkill/ResourceSkillService.cs
+++ b/Services/ResourceSkill/ResourceSkillService.cs
@@ -266,6 +266,7 @@ namespace DF_EvolutionAPI.Services
                     r.ResourceName,
                     r.TotalYears,
                     r.DateOfJoin,
+                    r.TenureInMonths, // ✅ Added this
                     rs.SkillExperience,
                     rs.SkillVersion,
                     rs.SkillDescription,
@@ -278,10 +279,10 @@ namespace DF_EvolutionAPI.Services
                     rs.RejectedComment,
                     rs.ResourceSkillId,
                     rs.IsDeleted,
-                    NewSkillId = skill != null ? skill.SkillId : 0, // Ensure default value
-                    SkillName = skill != null ? skill.Name : null, // Default name if null
-                    NewSubSkillId = subSkill != null ? subSkill.SubSkillId : 0, // Default value
-                    SubSkillName = subSkill != null ? subSkill.Name : null // Default name
+                    NewSkillId = skill != null ? skill.SkillId : 0,
+                    SkillName = skill != null ? skill.Name : null,
+                    NewSubSkillId = subSkill != null ? subSkill.SubSkillId : 0,
+                    SubSkillName = subSkill != null ? subSkill.Name : null
                 }
             ).ToListAsync();
 
@@ -333,13 +334,19 @@ namespace DF_EvolutionAPI.Services
                     skills.Add(skillModel);
                 }
 
+                var firstRecord = group.First();
+
+                // Calculate total experience using your method
+                var (years, months) = CalculateTotalExperience(
+                    (int)(firstRecord.TenureInMonths ?? 0),
+                    firstRecord.DateOfJoin
+                );
                 var fetchResourceSkill = new FetchResourceSkill
                 {
-                    ResourceId = group.Key,
-                    ResourceSkillId= group.First().ResourceSkillId,
-                    ResourceName = group.First().ResourceName,
-                    TotalYears= group.First().TotalYears,
-                    DateOfJoin= group.First().DateOfJoin,
+                    ResourceSkillId = firstRecord.ResourceSkillId,
+                    ResourceName = firstRecord.ResourceName,
+                    ResourceExp = $"{years}.{months}", // ✅ formatted experience
+                    DateOfJoin = firstRecord.DateOfJoin,
 
                     Skills = skills
                 };

--- a/Services/ResourceSkill/ResourceSkillService.cs
+++ b/Services/ResourceSkill/ResourceSkillService.cs
@@ -139,7 +139,7 @@ namespace DF_EvolutionAPI.Services
                                     var existingSubSkill = _dbContext.ResourceSkills
                                         .FirstOrDefault(rs => rs.ResourceId == resourceId
                                             && rs.SkillId == skill.SkillId
-                                            && rs.SubSkillId == subSkill.SubSkillId && rs.IsActive == 1 && rs.IsDeleted != 1);
+                                            && rs.SubSkillId == subSkill.SubSkillId && rs.IsActive == 1 && rs.IsDeleted == 0);
 
                                     if (existingSubSkill != null)
                                     {
@@ -156,7 +156,8 @@ namespace DF_EvolutionAPI.Services
                                         existingSubSkill.RejectedBy = 0;
                                         existingSubSkill.RejectedComment = null;
                                         existingSubSkill.IsApproved = 0;
-                                        existingSubSkill.ApprovedBy = 0;                                       
+                                        existingSubSkill.ApprovedBy = 0;
+                                        existingSkill.IsDeleted = 0;
 
                                         _dbContext.ResourceSkills.Update(existingSubSkill);
                                     }
@@ -180,7 +181,8 @@ namespace DF_EvolutionAPI.Services
                                             RejectedBy = 0,
                                             RejectedComment = null,
                                             IsApproved = 0,
-                                            ApprovedBy = 0,                                          
+                                            ApprovedBy = 0,
+                                            IsDeleted = 0,
                                         };
                                         _dbContext.ResourceSkills.Add(newSubSkill);
                                     }
@@ -236,7 +238,7 @@ namespace DF_EvolutionAPI.Services
                 }
 
                 await _dbContext.SaveChangesAsync(); // Commit changes
-                //log
+
                 model.IsSuccess = true;
                 model.Messsage = "Resource skills and subskills updated successfully.";
             }
@@ -257,13 +259,13 @@ namespace DF_EvolutionAPI.Services
                 from skill in skillGroup.DefaultIfEmpty()
                 join sub in _dbContext.SubSkills on rs.SubSkillId equals sub.SubSkillId into subSkillGroup
                 from subSkill in subSkillGroup.DefaultIfEmpty()
-                where rs.IsActive == (int)Status.IS_ACTIVE && rs.SkillId != 0 && r.StatusId==8
+                where rs.IsActive == (int)Status.IS_ACTIVE & rs.SkillId != 0
                 select new
                 {
                     r.ResourceId,
                     r.ResourceName,
+                    r.TotalYears,
                     r.DateOfJoin,
-                    r.TenureInMonths,
                     rs.SkillExperience,
                     rs.SkillVersion,
                     rs.SkillDescription,
@@ -276,10 +278,10 @@ namespace DF_EvolutionAPI.Services
                     rs.RejectedComment,
                     rs.ResourceSkillId,
                     rs.IsDeleted,
-                    NewSkillId = skill != null ? skill.SkillId : 0,
-                    SkillName = skill != null ? skill.Name : null,
-                    NewSubSkillId = subSkill != null ? subSkill.SubSkillId : 0,
-                    SubSkillName = subSkill != null ? subSkill.Name : null
+                    NewSkillId = skill != null ? skill.SkillId : 0, // Ensure default value
+                    SkillName = skill != null ? skill.Name : null, // Default name if null
+                    NewSubSkillId = subSkill != null ? subSkill.SubSkillId : 0, // Default value
+                    SubSkillName = subSkill != null ? subSkill.Name : null // Default name
                 }
             ).ToListAsync();
 
@@ -293,6 +295,8 @@ namespace DF_EvolutionAPI.Services
             foreach (var group in groupedResults)
             {
                 var skills = new List<SkillModel>();
+
+                // Group skills and subskills
                 var skillGroups = group.GroupBy(r => r.NewSkillId);
 
                 foreach (var skillGroup in skillGroups)
@@ -307,6 +311,9 @@ namespace DF_EvolutionAPI.Services
                             SubSkillExperience = r.SubSkillExperience,
                             SubSkillVersion = r.SubSkillVersion,
                             SubSkillDescription = r.SubSkillDescription,
+
+
+
                         }).ToList();
 
                     var skillModel = new SkillModel
@@ -326,21 +333,14 @@ namespace DF_EvolutionAPI.Services
                     skills.Add(skillModel);
                 }
 
-                var firstRecord = group.First();
-
-                // Calculate total experience using your method
-                var (years, months) = CalculateTotalExperience(
-                    (int)(firstRecord.TenureInMonths ?? 0),
-                    firstRecord.DateOfJoin
-                );
-
                 var fetchResourceSkill = new FetchResourceSkill
                 {
                     ResourceId = group.Key,
-                    ResourceSkillId = firstRecord.ResourceSkillId,
-                    ResourceName = firstRecord.ResourceName,
-                    ResourceExp = $"{years}.{months}", //Formatted experience
-                    DateOfJoin = firstRecord.DateOfJoin,
+                    ResourceSkillId= group.First().ResourceSkillId,
+                    ResourceName = group.First().ResourceName,
+                    TotalYears= group.First().TotalYears,
+                    DateOfJoin= group.First().DateOfJoin,
+
                     Skills = skills
                 };
 
@@ -571,7 +571,11 @@ namespace DF_EvolutionAPI.Services
                 return (0, 0);
             DateTime today = DateTime.Today;
             DateTime joinDate = dateOfJoin.Value;
-            int monthsSinceJoin = ((today.Year - joinDate.Year) * 12) + today.Month - joinDate.Month;           
+            int monthsSinceJoin = ((today.Year - joinDate.Year) * 12) + today.Month - joinDate.Month;
+            if (today.Day < joinDate.Day)
+            {
+                monthsSinceJoin -= 1;
+            }
             int totalMonthsExperience = tenureInMonths + monthsSinceJoin;
             int years = totalMonthsExperience / 12;
             int months = totalMonthsExperience % 12;

--- a/Services/ResourceSkill/ResourceSkillService.cs
+++ b/Services/ResourceSkill/ResourceSkillService.cs
@@ -115,7 +115,7 @@ namespace DF_EvolutionAPI.Services
                             foreach (var subSkill in skill.SubSkills)
                             {
                                 var existingSkill = _dbContext.ResourceSkills
-                                    .FirstOrDefault(rs => rs.ResourceId == resourceId && rs.SkillId == skill.SkillId && rs.IsActive == 1);
+                                    .FirstOrDefault(rs => rs.ResourceId == resourceId && rs.SkillId == skill.SkillId && rs.IsActive == 1 && rs.IsDeleted == 0);
 
                                 if (existingSkill != null && existingSkill.SubSkillId == null)
                                 {
@@ -368,7 +368,7 @@ namespace DF_EvolutionAPI.Services
                 from subSkill in subSkillGroup.DefaultIfEmpty()
                 join c in _dbContext.Categories on skill.CategoryId equals c.CategoryId into categoryGroup
                 from category in categoryGroup.DefaultIfEmpty()
-                where rs.IsActive == (int)Status.IS_ACTIVE && r.ResourceId == resourceId
+                where rs.IsActive == (int)Status.IS_ACTIVE && r.ResourceId == resourceId && rs.IsDeleted != 1
                 select new
                 {
                     r.ResourceId,


### PR DESCRIPTION
Corrected the user's skill data throughout the Search Skill page and the Resource Skill page.
Corrected the resource experience; a one-month discrepancy was appearing compared to PRMS.(In velocity the experience month will change on the date of joining of particular resource.)
Jira Ticket:
https://datafortune.atlassian.net/browse/VEL-160